### PR TITLE
Double check removal of KVO upon dealloc of ViewDeckController.

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -440,20 +440,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.originalShadowColor = nil;
     self.originalShadowOffset = CGSizeZero;
     self.originalShadowPath = nil;
-    
-    @try {
-        [self.centerController removeObserver:self forKeyPath:@"title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.iamge"];
-        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
-    } @catch(id anException) {}
-    @try {
-        [self removeObserver:self forKeyPath:@"parentViewController"];
-        [self removeObserver:self forKeyPath:@"presentingViewController"];
-    } @catch(id anException) {}
-    @try {
-        [self.view removeObserver:self forKeyPath:@"bounds"];
-    } @catch(id anException) {}
 
     _slidingController = nil;
     self.referenceView = nil;
@@ -464,6 +450,15 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (void)dealloc {
     [self cleanup];
     
+    // double check we've removed observation before nilling out the centerController
+    @try {
+        [self.centerController removeObserver:self forKeyPath:@"title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.image"];
+        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
+    } @catch(id anException) {
+        
+    }
     self.centerController.viewDeckController = nil;
     self.centerController = nil;
     self.leftController.viewDeckController = nil;
@@ -472,6 +467,18 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.rightController = nil;
     self.panners = nil;
     
+    // observations related to UIViewController properties
+    @try {
+        [self removeObserver:self forKeyPath:@"parentViewController"];
+        [self removeObserver:self forKeyPath:@"presentingViewController"];
+    } @catch(id anException) {
+        
+    }
+    @try {
+        [self.view removeObserver:self forKeyPath:@"bounds"];
+    } @catch(id anException) {
+    
+    }
 #if !II_ARC_ENABLED
     [super dealloc];
 #endif

--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -441,6 +441,20 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
     self.originalShadowOffset = CGSizeZero;
     self.originalShadowPath = nil;
     
+    @try {
+        [self.centerController removeObserver:self forKeyPath:@"title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
+        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.iamge"];
+        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
+    } @catch(id anException) {}
+    @try {
+        [self removeObserver:self forKeyPath:@"parentViewController"];
+        [self removeObserver:self forKeyPath:@"presentingViewController"];
+    } @catch(id anException) {}
+    @try {
+        [self.view removeObserver:self forKeyPath:@"bounds"];
+    } @catch(id anException) {}
+
     _slidingController = nil;
     self.referenceView = nil;
     self.centerView = nil;


### PR DESCRIPTION
There are situations where the viewDeckController may be deallocated without the normal view lifecycle delegate methods being called. This results in the "bounds" keyPath on the self.view observation remaining in place when the view is deallocated in the call to [super dealloc].

This change generalizes the issue to any observation which may have, for whatever reason, survived to dealloc. I grouped the removal attempts into separate @try blocks based on the grouping they have when created, and placed each block near to where the related field would be cleared.
