### PR TITLE
Remove always-redundant observation cleanup

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -450,15 +450,6 @@ static NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat velocit
 - (void)dealloc {
     [self cleanup];
     
-    // double check we've removed observation before nilling out the centerController
-    @try {
-        [self.centerController removeObserver:self forKeyPath:@"title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.title"];
-        [self.centerController removeObserver:self forKeyPath:@"tabBarItem.image"];
-        [self.centerController removeObserver:self forKeyPath:@"hidesBottomBarWhenPushed"];
-    } @catch(id anException) {
-        
-    }
     self.centerController.viewDeckController = nil;
     self.centerController = nil;
     self.leftController.viewDeckController = nil;


### PR DESCRIPTION
The centerController observers are cleaned up in the setCenterController
accessor. This is good; it means that the observations are already always
removed in dealloc, because the method calls setCenterController with nil.
